### PR TITLE
ユーザー登録時にユーザー名を登録できるよう変更

### DIFF
--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -94,6 +94,8 @@ paths:
                   minLength: 8
                   maxLength: 20
                   format: password
+                name:
+                  type: string
               required:
                 - email
                 - password
@@ -102,6 +104,7 @@ paths:
                 value:
                   email: user@example.com
                   password: pa$$word
+                  name: user
           application/javascript:
             schema:
               type: object
@@ -198,6 +201,11 @@ paths:
                 password:
                   type: string
                   format: password
+            examples:
+              example-1:
+                value:
+                  email: user@example.com
+                  password: pa$$word
       description: ログイン操作を実施し，アクセストークンを取得
     parameters: []
   /leader_board:


### PR DESCRIPTION
## WHY
* ログインに必要なメールアドレスだけでなく，アカウントを表示するときなどにユーザー名も必要なため

## WHAT
* `POST /auth` でパラメータとして `name` を送れるよう修正
* `POST /auth` `POST /auth/sign_in` のときに `name` フィールドも返却