### PR TITLE
APIのパス、レスポンスプロパティ等を修正

### DIFF
--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -326,6 +326,8 @@ paths:
                 description: ''
                 type: object
                 properties:
+                  message:
+                    type: string
                   competitionId:
                     type: string
                     minLength: 1
@@ -344,9 +346,6 @@ paths:
                           format: uri
                       required:
                         - assignmentId
-                required:
-                  - competitionId
-                  - images
               examples:
                 example:
                   value:
@@ -354,6 +353,9 @@ paths:
                     images:
                       - assignmentId: string
                         imageUrl: 'http://example.com'
+                competition_is_not_running:
+                  value:
+                    message: 'no competition is running'
         '401':
           description: Unauthorized
         '500':

--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -230,6 +230,8 @@ paths:
                         userName: string
                         annotationCount: string
                         rank: 1
+        '401':
+          description: Unauthorized
         '500':
           description: Internal Server Error
       operationId: get-leader_board

--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -210,21 +210,18 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  users:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        userId:
-                          type: string
-                        userName:
-                          type: string
-                        annotationCount:
-                          type: string
-                        rank:
-                          type: integer
+                type: array
+                items:
+                  type: object
+                  properties:
+                    userId:
+                      type: string
+                    userName:
+                      type: string
+                    annotationCount:
+                      type: string
+                    rank:
+                      type: integer
               examples:
                 example:
                   value:

--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -313,7 +313,7 @@ paths:
           in: header
           name: 'uid: <uid>'
           description: sign_inへのアクセス時headerで返却されたuid
-  /competitions/assignment:
+  /assignment:
     get:
       summary: Your GET endpoint
       tags: []

--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -253,7 +253,7 @@ paths:
           name: 'uid: <uid>'
           description: sign_inへのアクセス時headerで返却されたuid
       description: アノテーションコンペティションのリーダーボードの情報を取得（認証が必要）
-  /competition/next:
+  /competitions/next:
     get:
       summary: Your GET endpoint
       tags: []
@@ -314,7 +314,7 @@ paths:
           in: header
           name: 'uid: <uid>'
           description: sign_inへのアクセス時headerで返却されたuid
-  /competition/assignment:
+  /competitions/assignment:
     get:
       summary: Your GET endpoint
       tags: []

--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -265,10 +265,10 @@ paths:
                 description: ''
                 type: object
                 properties:
-                  competitionId:
+                  CompetitionId:
                     type: string
                     minLength: 1
-                  competitionName:
+                  CompetitionName:
                     type: string
                     minLength: 1
                   startAt:


### PR DESCRIPTION
## Why

実働している[バックエンドアプリケーション](https://github.com/mofumofu1729/reannotation-imagenet-backend)との仕様の差異があったため。

## What

以下を修正

- `competitions` EPのパスが `/competition`になっていた部分を `/competitions`に修正
- `leader_board` EPのレスポンスを修正
- `leader_board` EPの未認証時のレスポンスを追加
- `/competitions/next` のレスポンスBodyパラメータ名を修正
- `/assignment` EPのレスポンスBodyパラメータを修正