### PR TITLE
[WIP]返却されるJSONのキー名の大文字を小文字に修正

### DIFF
--- a/reference/annotation-competition-api.v1.yaml
+++ b/reference/annotation-competition-api.v1.yaml
@@ -273,10 +273,10 @@ paths:
                 description: ''
                 type: object
                 properties:
-                  CompetitionId:
+                  competitionId:
                     type: string
                     minLength: 1
-                  CompetitionName:
+                  competitionName:
                     type: string
                     minLength: 1
                   startAt:


### PR DESCRIPTION
## WHY
- 小文字から始めるべきJsonのキー名が大文字から始まってしまっているため

## WHAT
- キー名頭の大文字を小文字に修正
- (WIP) APIのキー名も修正